### PR TITLE
Fix changeset line construction

### DIFF
--- a/jj-mode.el
+++ b/jj-mode.el
@@ -363,9 +363,8 @@
                                   (insert "\n"))))))))
 
 (defun jj--parse-log-graph-line (line)
-  "Parse a line from jj log output to extract changeset info."
-  ;; Look for lines with commit markers (circles) followed by change IDs
-  (when (string-match "\\([○◉◆●◯◍@]\\)\\s-*\\([a-z][a-z0-9]+\\)" line)
+  "Parse LINE from jj log output to extract changeset info."
+  (when (string-match "\\([○◉×x◆●◯◍@]\\)\\s-*\\([a-z][a-z0-9]+\\)" line)
     (let* ((marker (match-string 1 line))
            (id (match-string 2 line))
            (rest (substring line (match-end 0)))


### PR DESCRIPTION
When conflicted, the default template renders an "x" which wasn't caught by this regexp.

This is definitely going to get more and more brittle as folks using nonstandard markers pick this up ([which jj allows](https://jj-vcs.github.io/jj/latest/config/#graph-style)).  

I might be able to hardcode a specific template style. 

Presently [the docs say](https://jj-vcs.github.io/jj/latest/FAQ/#i-want-to-write-a-tool-which-integrates-with-jujutsu-should-i-use-the-library-or-parse-the-cli) there is no good answer to this question. 

> #### I want to write a tool which integrates with Jujutsu. Should I use the library or parse the CLI?
>
> There are some trade-offs and there is no definitive answer yet.
> 
> - Using jj-lib avoids parsing command output and makes error handling easier.
> - jj-lib is not a stable API, so you may have to make changes to your tool when the API changes.
> - The CLI is not stable either, so you may need to make your tool detect the different versions and call the right command.
> - Using the CLI means that your tool will work with custom-built jj binaries, like the one at Google (if you're using the library, you will not be able to detect custom backends and more).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved jj log parsing to recognize the × commit marker, ensuring all entries display correctly in the log view.
  * Enhances compatibility with newer jj log output formats, reducing missed entries and parsing glitches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->