### PR TITLE
Does not fail if Magit is deferred

### DIFF
--- a/jj-mode.el
+++ b/jj-mode.el
@@ -1,5 +1,6 @@
 ;;; jj-mode.el -*- lexical-binding: t; -*-
 
+(require 'magit)
 (require 'magit-section)
 (require 'transient)
 (require 'ansi-color)


### PR DESCRIPTION
I just noticed that if Magit is loaded with:

```
(use-package magit
  :defer t
  ...)
```

then running `jj-log` would fail with:

```
or: Symbol’s function definition is void: magit-toplevel
```

Invoking any Magit's function would load Magit. After that, `jj-log` would correctly load.

This PR solved the issue adding `(require 'magit)`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved startup reliability by ensuring Magit loads before related components, preventing intermittent initialization errors in certain configurations. Startup now fails faster and more clearly if Magit is unavailable, reducing confusing load-order issues. Users should see more consistent behavior when activating the mode and interacting with Magit-powered features across different setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->