### PR TITLE
Fix bookmark prompt in git transient menu

### DIFF
--- a/jj-mode.el
+++ b/jj-mode.el
@@ -227,6 +227,11 @@
       (setq start (match-end 0)))
     (nreverse names)))
 
+(defun jj--get-bookmark-names ()
+  "Call to jj and get the list of local bookmarks."
+  (interactive)
+  (split-string (jj--run-command "bookmark" "list" "-T" "name ++ ' '") " " t))
+
 (defun jj--handle-push-result (cmd-args result success-msg)
   "Enhanced push result handler with bookmark analysis."
   (let ((trimmed-result (string-trim result)))
@@ -950,13 +955,13 @@
   (interactive (list (transient-args 'jj-git-transient)))
   (let* ((allow-new? (member "--allow-new" args))
          (all? (member "--all" args))
-         (bookmark-arg(seq-find (lambda (arg) (string-prefix-p "--bookmark=" arg)) args))
+         (bookmark-arg (seq-find (lambda (arg) (string-prefix-p "--bookmark=" arg)) args))
          (bookmark (when bookmark-arg (substring bookmark-arg 11)))
 
          (cmd-args (append '("git" "push")
                            (when allow-new? '("--allow-new"))
                            (when all? '("--all"))
-                           (when bookmark '("--bookmark" bookmark))))
+                           (when bookmark (list "--bookmark" bookmark))))
 
          (success-msg (if bookmark
                           (format "Successfully pushed bookmark %s" bookmark)
@@ -1278,12 +1283,12 @@
   :transient-non-suffix 'transient--do-warn
   ["Arguments"
    ("-n" "Allow new bookmarks" "--allow-new")
-   ("-b" "Bookmark" "--bookmark=" :reader transient-read-string)
+   ("-b" "Bookmark" "--bookmark="
+    :choices jj--get-bookmark-names)
    ("-a" "All" "--all")]
   [:description "JJ Git Operations"
    :class transient-columns
-   ["Actions"
-    ("p" "Push" jj-git-push
+   [("p" "Push" jj-git-push
      :transient nil)
     ("f" "Fetch" jj-git-fetch
      :transient nil)]


### PR DESCRIPTION
Fix for #9 

The problem was using transient-read-string.  Turns out transients offer a `:choices` option, which seems more appropriate.  

I discovered during testing that bookmark was being passed to the command as a symbol because of the quote.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Autocomplete suggestions for local bookmarks when choosing a bookmark to push.
  - Clearer push feedback with targeted guidance for bookmark restrictions, “nothing to push,” authentication issues, network errors, and rebase-like conflicts.

- Bug Fixes
  - Correctly passes the selected bookmark to the push command, ensuring reliable execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->