### PR TITLE
Installation instructions with use-package :vc

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,12 @@ interact with JJ repositories from within Emacs.
   :straight (:host github :repo "bolivier/jj-mode.el"))
 ```
 
+### use-package with built-in package-vc integration
+```lisp
+(use-package jj-mode
+  :vc (:url "https://github.com/bolivier/jj-mode.el"))
+```
+
 ### Manual
 Clone this repository and add it to your load path:
 ```lisp


### PR DESCRIPTION
I have neither straight nor Doom, so installed `jj-mode` with `use-package`, using the built-in package-vc integration. I thought that it was worth to be included in the instructions:

```lisp
(use-package jj-mode
  :vc (:url "https://github.com/bolivier/jj-mode.el"))
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added a “use-package with built-in package-vc integration” section to the README.
  - Included a code example showing how to install and configure jj-mode via use-package using a Git URL.
  - Sits alongside the existing “use-package with straight.el” example to offer an alternative installation path.
  - No code or public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->