### PR TITLE
Allow users to customize jj-log buffer.

### DIFF
--- a/jj-mode.el
+++ b/jj-mode.el
@@ -24,7 +24,14 @@
   :type 'boolean
   :group 'jj)
 
-;; (setq jj-mode-map nil)
+
+(defcustom jj-log-sections-hook '(jj-log-insert-logs
+                                  jj-log-insert-status
+                                  jj-log-insert-diff)
+  "Hook run to insert sections in the log buffer."
+  :type 'hook
+  :group 'jj)
+
 
 (defvar jj-mode-map
   (let ((map (make-sparse-keymap)))
@@ -507,9 +514,7 @@
         (erase-buffer)
         (jj-mode)
         (magit-insert-section (jjbuf)  ; Root section wrapper
-          (jj-log-insert-logs)
-          (jj-log-insert-status)
-          (jj-log-insert-diff))
+          (magit-run-section-hook 'jj-log-sections-hook))
         (goto-char (point-min))))
     (switch-to-buffer buffer)))
 
@@ -523,9 +528,7 @@
                                (pos (point)))
                            (erase-buffer)
                            (magit-insert-section (jjbuf)  ; Root section wrapper
-                             (jj-log-insert-logs)
-                             (jj-log-insert-status)
-                             (jj-log-insert-diff))
+                             (magit-run-section-hook 'jj-log-sections-hook))
                            (goto-char pos)
                            (jj--debug "Log refresh completed"))))))
 


### PR DESCRIPTION
Create a custom hook containing the functions used to insert `magit-sections` and run that instead of hardcoding the list in `jj-log` and `jj-log-refresh` (addresses #14).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a customizable hook to control which sections appear in the log buffer and their order, letting users reorder, add, or remove sections to tailor the view.
  * Applies to both initial log display and subsequent refreshes, preserving the default layout while enabling flexible, user-defined configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->