### PR TITLE
Stateful squash

### DIFF
--- a/jj-mode.el
+++ b/jj-mode.el
@@ -893,8 +893,9 @@
 
 (defun jj-squash-cleanup-on-exit ()
   "Clean up squash selections when transient exits."
-  (jj-squash-clear-selections)
-  (remove-hook 'transient-exit-hook 'jj-squash-cleanup-on-exit t))
+  (unless (eq this-command 'jj-mode-bury-squash)
+    (jj-squash-clear-selections)
+    (remove-hook 'transient-exit-hook 'jj-squash-cleanup-on-exit t)))
 
 ;; Squash transient menu
 ;;;###autoload
@@ -943,8 +944,12 @@
                       (format "Squash %s into parent" jj-squash-from))
                      (t "Execute squash (select commits first)")))
      :transient nil)
-    ("q" "Quit" transient-quit-one)]])
+    ("q" "Quit" transient-quit-one)
+    ("b" "Bury" jj-mode-bury-squash)]])
 
+(defun jj-mode-bury-squash ()
+  (interactive)
+  (transient-quit-one))
 
 (defun jj-bookmark-create ()
   "Create a new bookmark."


### PR DESCRIPTION
This PR, kindly co-authored by @protesilaos, implements the following behavior:

- When you enter the Squash transient, you can set `from` and `into` as usual, as well as navigate with `p` and `n` and complete the squash, as before. All the previous behaviors are maintained unaltered. No new configs are necessary.
- Quitting either with `q` or `ctrl-g`, or completing the squash, would clear the squash selections, as before.
- A new `b Bury` command is available. This gets back to the jj history tree, closing the transient without clearing the squash selections.
- In this case, both the local variables `jj-squash-from`/`jj-squash-into` and the overlays will be retained.
- This lets you freely navigate the jj history tree using tools other than `n` and `p` (such as avy, consult-line and the like).
- Re-entering the Squash transient lets you complete Squash.


This is obtained by adding a new:

```elisp
(defun jj-mode-bury-squash ()
  "Bury the transient squash transient retaining the squash selections."
  (interactive)
  (transient-quit-one))
```

and skipping the squash selections clearing with an `(unless (eq this-command 'jj-mode-bury-squash)` in `jj-squash-cleanup-on-exit`:

```elisp
(defun jj-squash-cleanup-on-exit ()
  "Clean up squash selections when transient exits."
  (unless (eq this-command 'jj-mode-bury-squash)
    (jj-squash-clear-selections)
    (remove-hook 'transient-exit-hook 'jj-squash-cleanup-on-exit t)))

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Bury” action to the squash panel, letting you hide the UI and return later while keeping your current selections and setup.

* **Improvements**
  * Cleanup on exit is now smarter: standard exits still clear selections, but burying no longer resets state, so you can resume your squash workflow seamlessly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->