### PR TITLE
Allow user to customize the display function for jj-log buffer.

### DIFF
--- a/jj-mode.el
+++ b/jj-mode.el
@@ -35,6 +35,16 @@
   :type 'hook
   :group 'jj)
 
+(defcustom jj-log-display-function #'pop-to-buffer
+  "Function called to display the jj log buffer.
+The function must accept one argument: the buffer to display."
+  :type '(choice
+          (function-item switch-to-buffer)
+          (function-item pop-to-buffer)
+          (function-item display-buffer)
+          (function :tag "Custom function"))
+:group 'jj)
+
 (defvar jj-mode-map
   (let ((map (make-sparse-keymap)))
     ;; Navigation
@@ -590,7 +600,7 @@ Lines may start with ASCII graph glyphs which are ignored."
         (magit-insert-section (jjbuf)  ; Root section wrapper
           (magit-run-section-hook 'jj-log-sections-hook))
         (goto-char (point-min))))
-    (switch-to-buffer buffer)))
+    (funcall jj-log-display-function buffer)))
 
 (defun jj-log-refresh (&optional _ignore-auto _noconfirm)
   "Refresh the jj log buffer."


### PR DESCRIPTION
Magit uses pop-to-buffer by default for example (and allows to be customized with `display-buffer-alist`). I've kerp the diff related functions using switch-buffer as I'm not sure we would want to use the same function for them but they would likely benefit from being customizable too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user-setting to control how the log view is displayed — choose switch to current window, pop up in a separate window, use standard display behavior, or supply a custom display function.
  * Default behavior now opens the log in a popped-up window; log content generation and population are unchanged while the final display action is configurable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->