### PR TITLE
Fix error getting PACKAGE-DESC

### DIFF
--- a/jj-mode.el
+++ b/jj-mode.el
@@ -1,4 +1,13 @@
-;;; jj-mode.el -*- lexical-binding: t; -*-
+;;; jj-mode.el --- A jujutsu vcs mode inspired by magit -*- lexical-binding: t; -*-
+
+;; Author: Brandon Olivier
+;; Keywords: jj, vcs, jujutsu, mode
+;; Package-Requires: ((emacs "26.1"))
+;; Homepage: https://github.com/bolivier/jj-mode.el
+
+;; This file is NOT part of GNU Emacs.
+
+;;; Code:
 
 (require 'magit)
 (require 'magit-section)


### PR DESCRIPTION
Hello Brandon, I'm an Emacs noob using Spacemacs, and got this error trying to load the mode:

```
Updating /Users/evaporei/.emacs.d/.cache/quelpa/build/jj-mode/
Skipping rebuild of /Users/evaporei/.emacs.d/quelpa/packages/jj-mode-20251014.162113.el
Error getting PACKAGE-DESC: (error Package lacks a file header)
```

I saw that another [mode](https://github.com/mattt-b/odin-mode/blob/master/odin-mode.el#L1) I use had a header and worked, so I did the same and it fixed the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added package header metadata (author, keywords, required versions, homepage) to the package header.
  * Improves visibility of package information in editors and package listings.
  * No behavioral, configuration, or performance changes; workflows remain unaffected.
  * No API or command changes; compatibility is unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->