### PR TITLE
run jj-diffedit-emacs from repo root

### DIFF
--- a/jj-mode.el
+++ b/jj-mode.el
@@ -695,7 +695,8 @@ The results of this fn are fed into `jj--parse-log-entries'."
 (defun jj-diffedit-emacs ()
   "Emacs-based diffedit using built-in ediff."
   (interactive)
-  (let* ((section (magit-current-section))
+  (let* ((default-directory (jj--root))
+         (section (magit-current-section))
          (file (cond
                 ((and section (eq (oref section type) 'jj-file-section))
                  (oref section file))


### PR DESCRIPTION
this fixes wrong paths when `default-directory` is not the repo root

obsoletes https://github.com/bolivier/jj-mode.el/pull/36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed diff-edit file resolution so operations consistently use the repository root. This prevents incorrect file selection when invoking diff-edit from subdirectories, making diff-editing more reliable and predictable across different working locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->