### PR TITLE
Ensure that output is never colorized unless explicitly requsted

### DIFF
--- a/jj-mode.el
+++ b/jj-mode.el
@@ -188,7 +188,7 @@ if(self.root(),
         result exit-code)
     (jj--debug "Running command: %s %s" jj-executable (string-join safe-args " "))
     (with-temp-buffer
-      (setq exit-code (apply #'process-file jj-executable nil t nil safe-args))
+      (setq exit-code (apply #'process-file jj-executable nil t nil "--color=never" "--no-pager" safe-args))
       (setq result (buffer-string))
       (jj--debug "Command completed in %.3f seconds, exit code: %d"
                  (float-time (time-subtract (current-time) start-time))


### PR DESCRIPTION
- Emacs over TRAMP can run jj inside pseudoterminal, causing it to color output
- If pager is used (like "delta") it may additionally color output even when jj itself doesn't do it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * External command output is now forced to plain text and paging is disabled, ensuring captured results are consistent and not interrupted by pagers. This improves reliability when running external tools, reduces unexpected interactive prompts, and leads to more predictable behavior when displaying or processing command output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->