### PR TITLE
Improve "bookmark tug" command

### DIFF
--- a/jj-mode.el
+++ b/jj-mode.el
@@ -1178,7 +1178,8 @@ With prefix ALL, include remote bookmarks."
 (defun jj-tug ()
   "Run jj tug command."
   (interactive)
-  (let ((result (jj--run-command "tug")))
+  (let* ((rev (or (jj-get-changeset-at-point) "@"))
+         (result (jj--run-command "bookmark" "move" "--from" (format "heads(::%s & bookmarks())" rev) "--to" rev)))
     (jj-log-refresh)
     (message "Tug completed: %s" (string-trim result))))
 


### PR DESCRIPTION
"Tug" used to call `jj tug` which is a non-standard alias.
Now instead of tugging bookmarks of @, it tugs bookmarks
for the *selected* change by default, like most other interactive
commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the tug command's workflow to use a revised bookmark management approach, improving how bookmarks are processed and resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->