### PR TITLE
Idiomatic naming for commit-id plist entry

### DIFF
--- a/jj-mode.el
+++ b/jj-mode.el
@@ -441,7 +441,7 @@ The results of this fn are fed into `jj--parse-log-entries'."
                            :line line
                            :elems (seq-remove (lambda (l) (or (not l) (string-blank-p l))) elems)
                            :author author
-                           :commit_id commit-id
+                           :commit-id commit-id
                            :short-desc short-desc
                            :long-desc  (if long-desc (json-parse-string long-desc) nil)
                            :timestamp  timestamp


### PR DESCRIPTION
:commit_id is not used for anything at the moment. But it is better to be consistent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated log entry data structure formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->