### PR TITLE
Go to current changeset after jj-log is open first time

### DIFF
--- a/jj-mode.el
+++ b/jj-mode.el
@@ -598,7 +598,7 @@ The results of this fn are fed into `jj--parse-log-entries'."
           (magit-insert-section-body
             (magit-run-section-hook 'jj-log-sections-hook))
           (insert "\n"))
-        (goto-char (point-min))))))
+        (jj-goto-current)))))
 
 (defun jj-log-refresh (&optional _ignore-auto _noconfirm)
   "Refresh the jj log buffer."


### PR DESCRIPTION
Current changeset is the most commont target for operations. Preselecting it is convenient.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cursor positioning in log buffers. The cursor now intelligently navigates to the current commit location after displaying logs, providing better navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->