### PR TITLE
Make jj--run-command-color respect jj-show-command-output

### DIFF
--- a/jj-mode.el
+++ b/jj-mode.el
@@ -209,6 +209,8 @@ if(self.root(),
         (jj--debug "Color command completed in %.3f seconds, exit code: %d"
                    (float-time (time-subtract (current-time) start-time))
                    exit-code)
+        (when (and jj-show-command-output (not (string-empty-p result)))
+          (jj--debug "Command output: %s" (string-trim result)))
         result))))
 
 (defun jj--run-command-async (callback &rest args)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conditional logging of command execution output when enabled. The system now captures trimmed results immediately after command completion for both standard and color-enabled command executions with non-empty results, providing enhanced visibility into command behavior and execution flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->