### PR TITLE
bookmark tug should operate on selected changeset

### DIFF
--- a/jj-mode.el
+++ b/jj-mode.el
@@ -1258,7 +1258,8 @@ With prefix ALL, include remote bookmarks."
 (defun jj-tug ()
   "Run jj tug command."
   (interactive)
-  (let ((result (jj--run-command "bookmark" "move" "--from" "heads(::@- & bookmarks())" "--to" "@-")))
+  (let* ((rev (or (jj-get-changeset-at-point) "@"))
+         (result (jj--run-command "bookmark" "move" "--from" (format "heads(::%s & bookmarks())" rev) "--to" rev)))
     (jj-log-refresh)
     (message "Tug completed: %s" (string-trim result))))
 


### PR DESCRIPTION
Operating on `@-` is inconsistent with the rest of the commands, which act on selected changeset.

(this is a shortened version of my other PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced the `tug` command to dynamically derive revision targets from your current position in the changeset, providing context-aware source and destination determination for more intelligent revision management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->