### PR TITLE
Add `before` and `after` actions to the `new` transient

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,9 @@ buffer (`*jj-log:project-name*`).
 - `u` - Undo last operation
 - `s` - Squash
 - `N` - New changeset here
+  - `n` create new changeset with options
+  - `a` create new changeset after bookmark with options
+  - `b` create new changeset before bookmark with options
 
 #### Advanced Operations
 - `r` - Rebase transient menu


### PR DESCRIPTION
This adds new actions to the `new` transient. 

They should make it easier to create new changesets from changesets that aren't visible right now (by reading from bookmarks).

They work with the args (although it's possible to create incompatible situations which will error).  

I think this supersedes #57, @lazy let me know if your use case isn't covered. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two new actions to create a changeset positioned after or before a selected bookmark or change id, with an interactive selection; if no target is chosen, creation defaults to the current changeset.
  * These actions are integrated into the existing changeset creation menu for a consistent workflow.

* **Documentation**
  * Updated README: the "N - New changeset" entry now opens a transient menu with sub-options (n, a, b) and prompts for before/after bookmark insertion.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->