### PR TITLE
Fix `new` transient issue

### DIFF
--- a/jj-mode.el
+++ b/jj-mode.el
@@ -1383,7 +1383,7 @@ With prefix ARG, open the transient menu for advanced options."
     ("-m" "Message" "--message=")
     ("-n" "No edit" "--no-edit")]
    ["Actions"
-    ("n" "Create new changeset" jj-new-after
+    ("n" "Create new changeset" jj-new-execute
      :transient nil)
     ("a" "Create after changeset" jj-new-after
      :transient nil)


### PR DESCRIPTION
I didn't notice the subtle difference between the raw call to jj-new-execute and jj-new-after. 

I'll add docs later, I want to make sure this is fixed immediately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the behavior of the "new changeset" shortcut in the transient menu to use the proper execution path.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->