### PR TITLE
fix: jj-diff with multiple repos

### DIFF
--- a/jj-mode.el
+++ b/jj-mode.el
@@ -1676,11 +1676,13 @@ Tries `jj git remote list' first, then falls back to `git remote'."
   "Show diff for current change or commit at point."
   (interactive)
   (let* ((change-id (jj-get-changeset-at-point))
+         (repo-root jj--repo-root)
          (buffer (get-buffer-create "*jj-diff*"))
          (prev-buffer (current-buffer)))
     (if (not change-id)
         (message "No diff to view at point.  Try again on a changeset.")
       (with-current-buffer buffer
+        (setq default-directory repo-root)
         (let ((inhibit-read-only t))
           (erase-buffer)
           (if change-id


### PR DESCRIPTION
Fix an issue which does not allow to use jj-diff with multiple repos

The `*jj-diff*` buffer takes on the `default-directory` from the repo that
    first invoked it and `jj diff` is run in the context of `*jj-diff*`.
    If invoked the first time from repo1, second invocation from repo2 will run in repo1 
    and repo2's change will not be recognized (throwing a `Error: Revision `asdf` doesn't exist`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured diff buffers run with the repository root as their working directory so diff operations and displayed paths are consistent regardless of the current file path.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->