### PR TITLE
Allow a non-numeric prefix to version string

### DIFF
--- a/jj-mode-test.el
+++ b/jj-mode-test.el
@@ -140,6 +140,9 @@ Each call to process-file pops the next value.  EXIT-CODE is constant."
 (defconst jj-test--version-string-new "jj 0.37.0\n"
   "Version string for jj >= 0.37.")
 
+(defconst jj-test--version-string-prefixed "jj google-0.38.0-abcxyz\n"
+  "Real `jj --version` output from a binary with prefixed version string.")
+
 (defconst jj-test--error-no-revision "Error: No such revision: abc123\n"
   "Error output for missing revision.")
 
@@ -259,6 +262,13 @@ Each call to process-file pops the next value.  EXIT-CODE is constant."
     (let ((jj--version nil))
       (let ((version (jj--get-version)))
         (should (equal version '(0 28 2)))))))
+
+(ert-deftest jj-test-get-version/skips-prefix ()
+  "Skips non-numeric prefix and correctly parses the version string into (major minor patch) list."
+  (jj-test-with-mock-commands jj-test--version-string-prefixed 0
+    (let ((jj--version nil))
+      (let ((version (jj--get-version)))
+        (should (equal version '(0 38 0)))))))
 
 (ert-deftest jj-test-get-version/caches-result ()
   "Version is cached after first call."

--- a/jj-mode-test.el
+++ b/jj-mode-test.el
@@ -143,6 +143,9 @@ Each call to process-file pops the next value.  EXIT-CODE is constant."
 (defconst jj-test--version-string-prefixed "jj google-0.38.0-abcxyz\n"
   "Real `jj --version` output from a binary with prefixed version string.")
 
+(defconst jj-test--version-string-current "jj 0.39.0\n"
+  "Real current `jj --version` output.")
+
 (defconst jj-test--error-no-revision "Error: No such revision: abc123\n"
   "Error output for missing revision.")
 
@@ -269,6 +272,13 @@ Each call to process-file pops the next value.  EXIT-CODE is constant."
     (let ((jj--version nil))
       (let ((version (jj--get-version)))
         (should (equal version '(0 38 0)))))))
+
+(ert-deftest jj-test-get-version/skips-prefix ()
+  "Parses a different plain version string into (major minor patch) list."
+  (jj-test-with-mock-commands jj-test--version-string-current 0
+    (let ((jj--version nil))
+      (let ((version (jj--get-version)))
+        (should (equal version '(0 39 0)))))))
 
 (ert-deftest jj-test-get-version/caches-result ()
   "Version is cached after first call."

--- a/jj-mode-test.el
+++ b/jj-mode-test.el
@@ -273,7 +273,7 @@ Each call to process-file pops the next value.  EXIT-CODE is constant."
       (let ((version (jj--get-version)))
         (should (equal version '(0 38 0)))))))
 
-(ert-deftest jj-test-get-version/skips-prefix ()
+(ert-deftest jj-test-get-version/parses-newer-version ()
   "Parses a different plain version string into (major minor patch) list."
   (jj-test-with-mock-commands jj-test--version-string-current 0
     (let ((jj--version nil))

--- a/jj-mode.el
+++ b/jj-mode.el
@@ -47,7 +47,7 @@
   "Get the jj version as a list of numbers (major minor patch)."
   (unless jj--version
     (let* ((version-string (jj--run-command "--version"))
-           (version-match (string-match "jj \\([0-9]+\\)\\.\\([0-9]+\\)\\.\\([0-9]+\\)" version-string)))
+           (version-match (string-match "jj [^0-9]*\\([0-9]+\\)\\.\\([0-9]+\\)\\.\\([0-9]+\\)" version-string)))
       (when version-match
         (setq jj--version (list (string-to-number (match-string 1 version-string))
                                 (string-to-number (match-string 2 version-string))


### PR DESCRIPTION
Some sites may prepend an arbitrary prefix to the version string, breaking the version parsing in the jj--get-version function.

This fixes parsing of the version string by skipping this (possibly non-existent) prefix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version detection to accept additional characters before the numeric version, increasing compatibility with varied version string formats.

* **Tests**
  * Added tests validating version parsing for outputs with non-numeric prefixes and for plain version outputs, ensuring robust detection across formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->