### PR TITLE
Add a command to push the current change

### DIFF
--- a/jj-mode-test.el
+++ b/jj-mode-test.el
@@ -575,6 +575,61 @@ Each call to process-file pops the next value.  EXIT-CODE is constant."
         (should (member "--dry-run" args))))))
 
 ;;; ============================================================
+;;; Arg Construction Tests — jj-git-push-change-at-point
+;;; ============================================================
+
+(ert-deftest jj-test-git-push-change-at-point/basic ()
+  "Basic push change at point with no flags."
+  (jj-test-with-mock-commands "" 0
+    (cl-letf (((symbol-function 'jj-log-refresh) #'ignore)
+              ((symbol-function 'jj-get-changeset-at-point)
+               (cl-constantly "klmnopqrstuv")))
+      (jj-git-push-change-at-point '())
+      (let ((args (jj-test--get-last-command-args)))
+        (should (member "git" args))
+        (should (member "push" args))
+        (should (member "--change" args))
+        (should (member "klmnopqrstuv" args))))))
+
+(ert-deftest jj-test-git-push-change-at-point/change-option ()
+  "Push change at point with a --change= arg."
+  (jj-test-with-mock-commands "" 0
+    (cl-letf (((symbol-function 'jj-log-refresh) #'ignore)
+              ((symbol-function 'jj-get-changeset-at-point)
+               (cl-constantly "klmnopqrstuv")))
+      (jj-git-push-change-at-point '("--change=wxyz"))
+      (let ((args (jj-test--get-last-command-args)))
+        (should (member "git" args))
+        (should (member "push" args))
+        (should (member "--change" args))
+        (should (member "klmnopqrstuv" args))
+        (should-not (member "wxyz" args))))))
+
+(ert-deftest jj-test-git-push-change-at-point/other-option ()
+  "Push change at point with a non-change arg."
+  (jj-test-with-mock-commands "" 0
+    (cl-letf (((symbol-function 'jj-log-refresh) #'ignore)
+              ((symbol-function 'jj-get-changeset-at-point)
+               (cl-constantly "klmnopqrstuv")))
+      (jj-git-push-change-at-point '("--remote=origin"))
+      (let ((args (jj-test--get-last-command-args)))
+        (should (member "git" args))
+        (should (member "push" args))
+        (should (member "--change" args))
+        (should (member "klmnopqrstuv" args))
+        (should (member "--remote" args))
+        (should (member "origin" args))))))
+
+(ert-deftest jj-test-git-push-change-at-point/no-change-at-point ()
+  "Push change at point errors when no change is available."
+  (jj-test-with-mock-commands "" 0
+    (cl-letf (((symbol-function 'jj-get-changeset-at-point)
+               (cl-constantly nil)))
+      (should-error (jj-git-push-change-at-point '("--remote=origin"))
+                    :type 'user-error)
+      (should (= (jj-test--command-count) 0)))))
+
+;;; ============================================================
 ;;; Arg Construction Tests — jj-git-fetch
 ;;; ============================================================
 

--- a/jj-mode.el
+++ b/jj-mode.el
@@ -1780,6 +1780,15 @@ Tries `jj git remote list' first, then falls back to `git remote'."
       (when (jj--handle-push-result cmd-args result success-msg)
         (jj-log-refresh)))))
 
+(defun jj-git-push-change-at-point (args)
+  "Push the change at point with ARGS."
+  (interactive (list (transient-args 'jj-git-push-transient)))
+  (let ((change (jj-get-changeset-at-point)))
+    (unless change
+      (user-error "No change at point"))
+    (let ((filtered-args (seq-remove (lambda (arg) (string-prefix-p "--change=" arg)) args)))
+      (jj-git-push (cons (concat "--change=" change) filtered-args)))))
+
 (defun jj-commit ()
   "Open commit message buffer."
   (interactive)
@@ -2154,6 +2163,7 @@ Tries `jj git remote list' first, then falls back to `git remote'."
            ("-N" "Named X=REV" "--named=")
            ("-y" "Dry run" "--dry-run")]
           [("p" "Push" jj-git-push :transient nil)
+           ("c" "Push change at point" jj-git-push-change-at-point :transient nil)
            ("q" "Quit" transient-quit-one)]])
 
 ;; Fetch transient and command


### PR DESCRIPTION
The command is registered in the Git push transient as an alternative action, passing `--change=<change-at-point>` to the push command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a "Push change at point" action to detect the change under the cursor and push it directly; signals an error if no change is found.
* **Tests**
  * Adds unit tests ensuring the push action builds correct git push arguments, drops conflicting --change flags, and handles missing-change errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->